### PR TITLE
Fix dynamically linked binary issues when the agent runs on servers without glibc such as containers and pods

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 # Go parameters
 GO_CMD=go
-GO_BUILD=$(GO_CMD) build
+# GO_BUILD=$(GO_CMD) build
+GO_BUILD = CGO_ENABLED=0 $(GO_CMD) build -a -ldflags '-s -w'
 BINARY_NAME=GC2
 
 # List of target OS/Arch combinations


### PR DESCRIPTION
# Introduction
Currently, the compiled binaries do not work on Linux servers without libc, such as containers or pods, because the compilation parameters make the agent dynamically linked to the system's GLIBC, rather than embedding this dependency within the binary itself.

# Test (Error) Case  of use

Commun GLIBC error when i try execute on container

```
$ /tmp/gc2

/tmp/gc2: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /tmp/gc2)
/tmp/gc2: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /tmp/gc2)
```

# General Information

Before (Original makefile)

```
ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=KKuqSYjsVk0JGnGDEyNe/PxuFIzLp3XIiNPpeBWuE/Kk9jeTd3d4G3g5wfkOvP/sJ0b5w64U5Nq1Nx0TUfQ, with debug_info, not stripped

Length: 18M
```

After (New makefile)

```
ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=fcGaQQOtoOzkn-CU0gFK/vO6Xe0EMMuA4zSYrs6G_/DjLYp1ZPlA8Dr262e3nH/QO2xMDyXKp3Vy5e2KvJj, stripped

Length: 13M
```

I hope i've holped. Congrats for this amazing project <3.